### PR TITLE
Properly finds libraries and header files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 import PackageDescription
 
 let package = Package(
-    name: "COPUS"
+    name: "COPUS",
+    pkgConfig: "opus"
 )

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,5 +1,5 @@
 module COPUS [system] {
-  header "/usr/local/include/opus/opus.h"
+  header "shim.h"
   link "opus"
   export *
 }

--- a/shim.h
+++ b/shim.h
@@ -1,6 +1,6 @@
 #ifndef __COPUS_SHIM_H__
 #define __COPUS_SHIM_H__
 
-#include <opus/opus.h>
+#include <opus.h>
 
 #endif

--- a/shim.h
+++ b/shim.h
@@ -1,0 +1,6 @@
+#ifndef __COPUS_SHIM_H__
+#define __COPUS_SHIM_H__
+
+#include <opus/opus.h>
+
+#endif


### PR DESCRIPTION
- Added `pkgConfig: "opus"` to the Package.swift, which will allow the Swift package manager to get the proper include directories and linker search directories.
- Switched the explicit include of `/usr/local/include/opus/opus.h` with a shim that includes `<opus.h>`, which should resolve to the correct header even if it isn't in `/usr/local/include/opus/opus.h`